### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ You can register any module in the Profile module using the `register_module/3` 
 defmodule MyMirror.Profiles.Default do
   use Snowhite.Builder.Profile
 
-  register_module(:top_left, Snowhite.Modules.Clock, locale: "fr")
+  configure(
+    locale: "fr"
+  )
+
+  register_module(:top_left, Snowhite.Modules.Clock) # will be french
+  register_module(:top_left, Snowhite.Modules.Clock, locale: "en") # will be english
 end
 ```
 

--- a/dev.exs
+++ b/dev.exs
@@ -33,32 +33,22 @@ Application.put_env(:snowhite, SnowhiteDemo.Endpoint,
 defmodule Snowhite.Profiles.Default do
   use Snowhite.Builder.Profile
 
-  @timezone "America/Toronto"
-  @city_id "6167865"
-  @locale "en"
-  @units :metric
-
-  register_module(:top_left, Snowhite.Modules.Clock, timezone: @timezone, locale: @locale)
-
-  register_module(:top_left, Snowhite.Modules.Calendar, timezone: @timezone, locale: @locale)
-
-  register_module(:top_right, Snowhite.Modules.Weather.Current,
-    city_id: @city_id,
-    locale: @locale,
-    units: @units,
-    refresh: ~d(4h)
+  configure(
+    locale: "en",
+    city_id: "6167865",
+    units: :metric,
+    timezone: "America/Toronto"
   )
 
-  register_module(:top_right, Snowhite.Modules.Weather.Forecast,
-    city_id: @city_id,
-    locale: @locale,
-    units: @units,
-    refresh: ~d(4h)
-  )
+  register_module(:top_left, Snowhite.Modules.Clock)
+
+  register_module(:top_left, Snowhite.Modules.Calendar)
+
+  register_module(:top_right, Snowhite.Modules.Weather.Current, refresh: ~d(4h))
+
+  register_module(:top_right, Snowhite.Modules.Weather.Forecast, refresh: ~d(4h))
 
   register_module(:top_right, Snowhite.Modules.Suntime,
-    timezone: @timezone,
-    locale: @locale,
     latitude: 43.653225,
     longitude: -79.383186
   )

--- a/guides/changelog.md
+++ b/guides/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.1.0
+
+### New
+
+- Module options can now be globally defined using `configure/1` macro in Profiles. Example:
+
+```elixir
+configure(locale: "fr")
+
+register_module(:top_left, Snowhite.Modules.Clock) # Will be french
+register_module(:top_left, Snowhite.Modules.Clock, locale: "en") # Will be english
+```
+
 ## 1.0.0
 
 ### Deprecations

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Snowhite.MixProject do
 
   @github "https://github.com/nicklayb/snowhite"
   @description "Smart mirror framework"
-  @version "1.0.0"
+  @version "1.1.0"
   def project do
     [
       app: :snowhite,

--- a/mix.exs
+++ b/mix.exs
@@ -100,6 +100,7 @@ defmodule Snowhite.MixProject do
         Snowhite.Modules.Weather.Forecast,
         Snowhite.Modules.Rss,
         Snowhite.Modules.Rss.Poller,
+        Snowhite.Modules.Rss.RssItem,
         Snowhite.Modules.Rss.UrlShortener,
         Snowhite.Modules.Suntime,
         Snowhite.Modules.Suntime.Server
@@ -109,7 +110,8 @@ defmodule Snowhite.MixProject do
         Snowhite.Modules.Rss.Server,
         Snowhite.Modules.Weather.Server,
         Snowhite.Modules.Suntime.Server,
-        Snowhite.Scheduler
+        Snowhite.Scheduler,
+        Snowhite.Scheduler.Schedule
       ],
       Helpers: [
         Snowhite.Helpers.Casing,
@@ -123,6 +125,7 @@ defmodule Snowhite.MixProject do
       ],
       Clients: [
         OpenWeather,
+        OpenWeather.Coord,
         OpenWeather.Forecast,
         OpenWeather.Forecast.City,
         OpenWeather.Forecast.ForecastItem,


### PR DESCRIPTION
- Adds support for global configuration through `configure/1` macro. This is the expected behaviour to not have those app-wide as you might be interested in configuring multiple profiles differently.